### PR TITLE
Fix the name in the readme (Replace Gunvicorn with Uvicorn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Restart Apache2
 
 Uvicorn is the default application server for GOG DB, but any other ASGI server can be used.
 
-Install Gunicorn
+Install Uvicorn
 
     # apt install uvicorn
 


### PR DESCRIPTION
A simple fix for the README replacing Gunvicorn with Uvicorn in the install step as it installs Uvicorn, not Gunvicorn.