### PR TITLE
add extraction of properties from api.gog v2

### DIFF
--- a/gogdb/core/model.py
+++ b/gogdb/core/model.py
@@ -77,6 +77,11 @@ class Download:
     files: List[File]
 
 @defaultdataclass
+class Property:
+    name: str
+    slug: str
+
+@defaultdataclass
 class BonusDownload(Download):
     bonus_type: str
     count: int
@@ -222,6 +227,7 @@ class Product:
     access: int
 
     features: List[Feature]
+    properties: List[Property]
     localizations: List[Localization]
     tags: List[Tag]
     cs_systems: List[str]

--- a/gogdb/templates/product_info.html
+++ b/gogdb/templates/product_info.html
@@ -153,6 +153,10 @@
       <td>{{ product.features | comma_attr("name") | nodata }}</td>
     </tr>
     <tr>
+      <td>Properties</td>
+      <td>{{ product.properties | comma_attr("name") | nodata }}</td>
+    </tr>
+    <tr>
       <td>Localizations</td>
       <td>{{ product.localizations | comma_attr("name") | nodata }}</td>
     </tr>

--- a/gogdb/updater/dataextractors.py
+++ b/gogdb/updater/dataextractors.py
@@ -116,6 +116,14 @@ def extract_properties_v2(prod, v2_cont):
             name=x["name"]
         ) for x in v2_embed["features"]
     ]
+
+    prod.properties = [
+        model.Property(
+            name=x["name"],
+            slug=x["slug"]
+        ) for x in v2_embed["properties"]
+    ]
+
     localizations_map = collections.defaultdict(lambda: model.Localization())
     for loc in v2_embed["localizations"]:
         loc_embed = loc["_embedded"]


### PR DESCRIPTION
This PR adds the extraction of `properties` data that is returned from a request to `https://api.gog.com/v2`.

<img width="817" height="1340" alt="image" src="https://github.com/user-attachments/assets/9d808112-7a75-4563-b1ca-5256619899ea" />

I need an assistance with this PR tho:
1. Please, run data collection and make sure this code works. Python code should work but I have a hard time running the code locally.
2. I'm not sure if I need to update DB scheme or something.